### PR TITLE
Updated faq to only say that there are no waves and just one registration open date

### DIFF
--- a/config/faqs.tsx
+++ b/config/faqs.tsx
@@ -108,16 +108,8 @@ export default function getFaqs(dates: Dates): FAQ[] {
           <Fragment>Ticket sales have closed.</Fragment>
         ) : (
           <Fragment>
-            Due to the popularity of last years event, we are running 2 separate ticket waves to give everyone an
-            opportunity to obtain a ticket.
-            <br />
-            <br />
-            Wave 1 registration opens on {format(Conference.RegistrationOpenFrom, dates.DateDisplayFormat)} at{' '}
+            Registration opens on {format(Conference.RegistrationOpenFrom, dates.DateDisplayFormat)} at{' '}
             {format(Conference.RegistrationOpenFrom, dates.TimeDisplayFormat)}.<br />
-            Wave 2 registration opens on {format(Conference.Wave2RegistrationOpenFrom, dates.DateDisplayFormat)} at{' '}
-            {format(Conference.Wave2RegistrationOpenFrom, dates.TimeDisplayFormat)}.<br />
-            <br />
-            The ticket price will stay at {Conference.TicketPrice} for each wave.
           </Fragment>
         )}
       </Fragment>


### PR DESCRIPTION
New registration faq response

<img width="817" alt="image" src="https://github.com/user-attachments/assets/ac5ef50b-20dc-4e76-ac1c-dc8e43a524ed">