### PR TITLE
Agenda layout updates for workshop continuations

### DIFF
--- a/components/Agenda/Agenda.styled.tsx
+++ b/components/Agenda/Agenda.styled.tsx
@@ -134,9 +134,27 @@ export const StyledUpNext = styled('div')(({ theme }) => ({
 }))
 StyledUpNext.displayName = 'StyledUpNext'
 
-export const StyledAgendaContainer = styled('div')(({ theme }) => ({
+interface StyledAgendaContainerProps {
+  talkTracks?: number,
+  workshopTracks?: number
+}
+
+export const StyledAgendaContainer = styled('div')<StyledAgendaContainerProps>(({ theme, talkTracks = 4, workshopTracks = 1 }) => ({
   position: 'relative',
   marginBottom: calcRem(theme.metrics.xl),
+  display: 'grid',
+  gridTemplateColumns: `repeat(2, 1fr)`,
+  backgroundColor: '#ddd',
+  border: cellBorder,
+  textAlign: 'center',
+  gap: calcRem(1),
+
+
+// NEW CODE - maybe need to remove or override the above instead?  and use tracks for the repeating part?
+  [breakpoint(tableLayoutBreakpointFrom)]: {
+    gridTemplateColumns: `${calcRem(90)} repeat(${talkTracks}, 1fr) repeat(${workshopTracks}, [workshops] 1fr);`
+  },
+
 }))
 StyledAgendaContainer.displayName = 'StyledAgendaContainer'
 

--- a/components/Agenda/Agenda.styled.tsx
+++ b/components/Agenda/Agenda.styled.tsx
@@ -71,7 +71,7 @@ StyledAgendaRow.displayName = 'StyledAgendaRow'
 
 export const StyledAgendaTimeRoomCell = styled('div')<StyledAgendaTimeRoomCellProps>(({ theme, room }) => ({
   position: 'sticky',
-  top: 100,
+  top: 75,
   display: 'none',
   padding: calcRem(theme.metrics.md),
   backgroundColor: room ? room : theme.colors.dddpurple,

--- a/components/Agenda/Agenda.styled.tsx
+++ b/components/Agenda/Agenda.styled.tsx
@@ -6,6 +6,11 @@ import { tableLayoutBreakpointFrom } from './layout'
 const rowBackgroundColor = '#f9f9f9'
 const cellBorder = '1px solid #ddd'
 
+
+interface StyledAgendaTimeRoomCellProps {
+  room?: string
+}
+
 interface StyledAgendaRowProps {
   tracks?: number
 }
@@ -63,6 +68,22 @@ export const StyledAgendaRow = styled('section')<StyledAgendaRowProps>(({ tracks
   },
 }))
 StyledAgendaRow.displayName = 'StyledAgendaRow'
+
+export const StyledAgendaTimeRoomCell = styled('div')<StyledAgendaTimeRoomCellProps>(({ theme, room }) => ({
+  position: 'sticky',
+  top: 100,
+  display: 'none',
+  padding: calcRem(theme.metrics.md),
+  backgroundColor: room ? room : theme.colors.dddpurple,
+  color: room ? 'inherit' : theme.colors.white,
+  fontSize: calcRem(20),
+  fontWeight: theme.weights.bold,
+  textAlign: 'center',
+ 
+  [breakpoint(tableLayoutBreakpointFrom)]: {
+      display: 'block'
+  }
+}))
 
 export const StyledAgendaRowList = styled('ul')(({ theme }) => ({
   position: 'sticky',

--- a/components/Agenda/AgendaSession.styled.tsx
+++ b/components/Agenda/AgendaSession.styled.tsx
@@ -6,15 +6,28 @@ import { tableLayoutBreakpointFrom } from './layout'
 
 interface StyledSectionProps {
   fullWidth?: boolean
+  excludeWorkshopTrack?: boolean
   session?: boolean
+  isWorkshop?: boolean
+  isWorkshopContinuation?: boolean
 }
 
-export const StyledSection = styled('section')<StyledSectionProps>(({ fullWidth, session }) => ({
+export const StyledSection = styled('section')<StyledSectionProps>(({ fullWidth, excludeWorkshopTrack, session, isWorkshop, isWorkshopContinuation }) => ({
   padding: session ? undefined : calcRem(20, 8),
+  backgroundColor: `#f9f9f9`,
+  gridColumn: fullWidth ? 'span 5' : 'auto' /*'auto'*/,
 
   [breakpointMax(tableLayoutBreakpointFrom)]: {
-    gridColumn: fullWidth ? '1 / -1' : 'auto',
+    gridColumn: fullWidth ? 'span 2' : 'auto' /*'auto'*/,
   },
+
+  [breakpoint(tableLayoutBreakpointFrom)]: {
+    gridRow: isWorkshop ? 'span 3' : 'auto',
+    gridColumn: excludeWorkshopTrack 
+      ? '2 / workshops' 
+      : fullWidth ? 'span 5' : 'auto',
+    display: isWorkshopContinuation ? 'none' : 'inherit'
+  }
 }))
 StyledSection.displayName = 'StyledSection'
 

--- a/components/Agenda/AgendaSession.tsx
+++ b/components/Agenda/AgendaSession.tsx
@@ -17,7 +17,10 @@ interface AgendaSessionProps {
   alwaysShowRoom?: boolean
   sponsorId?: string
   fullWidth?: boolean
+  excludeWorkshopTrack?: boolean,
   isKeynote?: boolean
+  isWorkshop?: boolean
+  isWorkshopContinuation?: boolean
   renderTitle?: (title: string) => React.ReactNode
   renderPresenters?: (presenters: string) => React.ReactNode
 }
@@ -29,7 +32,10 @@ export const AgendaSession = ({
   alwaysShowRoom,
   sponsorId,
   fullWidth,
+  excludeWorkshopTrack,
   isKeynote,
+  isWorkshop,
+  isWorkshopContinuation,
   renderTitle,
   renderPresenters,
 }: AgendaSessionProps) => {
@@ -39,7 +45,12 @@ export const AgendaSession = ({
   const presenters = session ? session.Presenters.map((p) => p.Name).join(', ') : ''
 
   return (
-    <StyledSection fullWidth={fullWidth} session={session !== false}>
+    <StyledSection 
+      fullWidth={fullWidth} 
+      session={session !== false} 
+      isWorkshop={isWorkshop} 
+      isWorkshopContinuation={isWorkshopContinuation}
+      excludeWorkshopTrack={excludeWorkshopTrack}>
       {!session && !children && <StyledAgendaPresenter>Loading&hellip;</StyledAgendaPresenter>}
       {session && (
         <StyledAgendaButton

--- a/components/Agenda/Agendatime.styled.tsx
+++ b/components/Agenda/Agendatime.styled.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled'
 import { tableLayoutBreakpointFrom } from './layout'
 
 export const StyledAgendaTime = styled('div')(({ theme }) => ({
-  gridColumn: `1 / -1`,
+  gridColumn: 'span 2', // `1 / -1`,
   padding: calcRem(10),
   backgroundColor: theme.colors.secondary,
   color: '#fff',
@@ -12,8 +12,9 @@ export const StyledAgendaTime = styled('div')(({ theme }) => ({
 
   [breakpoint(tableLayoutBreakpointFrom)]: {
     gridColumn: 'auto',
-    backgroundColor: 'transparent',
+    backgroundColor: '#f9f9f9', // 'transparent',
     color: 'inherit',
+    gridRow: 'auto'
   },
 }))
 StyledAgendaTime.displayName = 'StyledAgendaTime'

--- a/components/currentAgenda.tsx
+++ b/components/currentAgenda.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react'
+import { theme } from 'components/utils/styles/theme'
 import Conference from 'config/conference'
 import { Session, Sponsor } from 'config/types'
 import { ActionButton } from 'components/actionButton'
@@ -95,28 +96,23 @@ export const CurrentAgenda = ({
                   </StyledAgendaRow>
                 </StyledUpNext>
               )}
-              <StyledAgendaContainer>
-                <StyledAgendaRowList>
+              <StyledAgendaContainer talkTracks={4} workshopTracks={1}>
+                {/* <StyledAgendaRowList>
                   <li>Time</li>
                   {Conference.RoomNames.map((name) => (
                     <li style={{ backgroundColor: `${Conference.RoomColors[name]}`, color: 'inherit' }} key={name}>
                       {name}
                     </li>
                   ))}
-                </StyledAgendaRowList>
-                <StyledAgendaRow>
+                </StyledAgendaRowList> */}
                   <AgendaTime time={set(date, { hours: 8, minutes: 0 })} />
                   <AgendaSession room="" alwaysShowRoom fullWidth>
                     <StyledTrackHeader>Registration</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 8, minutes: 45 })} />
                   <AgendaSession room={0} alwaysShowRoom fullWidth>
                     <StyledTrackHeader>Welcome and Housekeeping</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 9, minutes: 0 })} duration={45} />
                   <AgendaSession
                     sessionId="1039434"
@@ -128,14 +124,10 @@ export const CurrentAgenda = ({
                     isKeynote
                     alwaysShowRoom
                   />
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 9, minutes: 45 })} />
                   <AgendaSession fullWidth>
                     <StyledTrackHeader>Morning Tea</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 10, minutes: 15 })} duration={45} />
                   <AgendaSession
                     room={0}
@@ -147,19 +139,16 @@ export const CurrentAgenda = ({
                   <AgendaSession room={3} sessionId="1044802" />
                   <AgendaSession
                     room={4}
+                    isWorkshop
                     sessionId="988090"
                     renderTitle={(title) => (
-                      <StyledAgendaTitle>{title}<br />(Part 1)</StyledAgendaTitle>
+                      <StyledAgendaTitle>{title}</StyledAgendaTitle>
                     )}
                   />
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 11, minutes: 0 })} />
-                  <AgendaSession fullWidth>
+                  <AgendaSession fullWidth excludeWorkshopTrack>
                     <StyledTrackHeader>Changeover</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 11, minutes: 15 })} duration={45} />
                   <AgendaSession
                     room={0}
@@ -171,19 +160,17 @@ export const CurrentAgenda = ({
                   <AgendaSession room={3} sessionId="990488" />
                   <AgendaSession
                     room={4}
+                    isWorkshop
+                    isWorkshopContinuation
                     sessionId="988090"
                     renderTitle={(title) => (
-                      <StyledAgendaTitle>{title}<br />(Part 2)</StyledAgendaTitle>
+                      <StyledAgendaTitle>{title}<br />(continued)</StyledAgendaTitle>
                     )}
                   />
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 12, minutes: 0 })} />
                   <AgendaSession fullWidth>
                     <StyledTrackHeader>Changeover</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow tracks={4}>
                   <AgendaTime time={set(date, { hours: 12, minutes: 15 })} duration={20} />
                   <AgendaSession
                     room={0}
@@ -196,14 +183,10 @@ export const CurrentAgenda = ({
                   <AgendaSession>
                     <StyledTrackHeader />
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 12, minutes: 35 })} />
                   <AgendaSession room="" alwaysShowRoom fullWidth>
                     <StyledTrackHeader>Lunch</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 13, minutes: 30 })} duration={45} />
                   <AgendaSession
                     room={0}
@@ -220,15 +203,10 @@ export const CurrentAgenda = ({
                       <StyledAgendaTitle>{title}<br />(Part 1)</StyledAgendaTitle>
                     )}
                   />
-                </StyledAgendaRow>
-
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 14, minutes: 15 })} />
                   <AgendaSession fullWidth>
                     <StyledTrackHeader>Changeover</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 14, minutes: 30 })} duration={45} />
                   <AgendaSession
                     room={0}
@@ -245,15 +223,10 @@ export const CurrentAgenda = ({
                       <StyledAgendaTitle>{title}<br />(Part 2)</StyledAgendaTitle>
                     )}
                   />
-                </StyledAgendaRow>
-
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 15, minutes: 15 })} />
                   <AgendaSession fullWidth>
                     <StyledTrackHeader>Afternoon Tea</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 15, minutes: 45 })} duration={45} />
                   <AgendaSession
                     room={0}
@@ -266,14 +239,10 @@ export const CurrentAgenda = ({
                   <AgendaSession>
                     <StyledTrackHeader />
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 16, minutes: 30 })} />
                   <AgendaSession fullWidth>
                     <StyledTrackHeader>Changeover</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 16, minutes: 45 })} duration={60} />
                   <AgendaSession
                     sessionId="988046"
@@ -285,14 +254,10 @@ export const CurrentAgenda = ({
                     isKeynote
                     alwaysShowRoom
                   />
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime time={set(date, { hours: 17, minutes: 15 })} />
                   <AgendaSession room={0} alwaysShowRoom fullWidth>
                     <StyledTrackHeader>Closing</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
-                <StyledAgendaRow>
                   <AgendaTime
                     time={set(date, { hours: 18, minutes: 0 })}
                     endTime={set(date, { hours: 20, minutes: 30 })}
@@ -300,7 +265,6 @@ export const CurrentAgenda = ({
                   <AgendaSession room="Beer Deluxe, Federation Square" alwaysShowRoom fullWidth>
                     <StyledTrackHeader>Afterparty</StyledTrackHeader>
                   </AgendaSession>
-                </StyledAgendaRow>
               </StyledAgendaContainer>
             </AgendaProvider>
           )

--- a/components/currentAgenda.tsx
+++ b/components/currentAgenda.tsx
@@ -4,7 +4,7 @@ import { Session, Sponsor } from 'config/types'
 import { ActionButton } from 'components/actionButton'
 import { Agenda } from 'components/Agenda/Agenda'
 import {
-  StyledAgendaRow,
+  StyledAgendaTimeRoomCell,
   StyledFeedbackActions,
   StyledTrackHeader,
   StyledUpNext,
@@ -66,7 +66,7 @@ export const CurrentAgenda = ({
               {Conference.ShowNextSessions && nextSessionGroup && nextSessionGroup.sessions.length > 0 && (
                 <StyledUpNext>
                   <h2>Up next</h2>
-                  <StyledAgendaRow>
+                  <StyledAgendaContainer talkTracks={4} workshopTracks={1}>
                     <AgendaTime time={nextSessionGroup.timeStart} />
                     {nextSessionGroup.sessions.map((session, index) =>
                       Array.isArray(session) ? (
@@ -91,18 +91,16 @@ export const CurrentAgenda = ({
                         />
                       ),
                     )}
-                  </StyledAgendaRow>
+                  </StyledAgendaContainer>
                 </StyledUpNext>
               )}
               <StyledAgendaContainer talkTracks={4} workshopTracks={1}>
-                {/* <StyledAgendaRowList>
-                  <li>Time</li>
+                  <StyledAgendaTimeRoomCell>Time</StyledAgendaTimeRoomCell>
                   {Conference.RoomNames.map((name) => (
-                    <li style={{ backgroundColor: `${Conference.RoomColors[name]}`, color: 'inherit' }} key={name}>
+                    <StyledAgendaTimeRoomCell room={Conference.RoomColors[name]} key={name}>
                       {name}
-                    </li>
+                    </StyledAgendaTimeRoomCell>
                   ))}
-                </StyledAgendaRowList> */}
                   <AgendaTime time={set(date, { hours: 8, minutes: 0 })} />
                   <AgendaSession room="" alwaysShowRoom fullWidth>
                     <StyledTrackHeader>Registration</StyledTrackHeader>

--- a/components/currentAgenda.tsx
+++ b/components/currentAgenda.tsx
@@ -1,12 +1,10 @@
 import React, { Fragment } from 'react'
-import { theme } from 'components/utils/styles/theme'
 import Conference from 'config/conference'
 import { Session, Sponsor } from 'config/types'
 import { ActionButton } from 'components/actionButton'
 import { Agenda } from 'components/Agenda/Agenda'
 import {
   StyledAgendaRow,
-  StyledAgendaRowList,
   StyledFeedbackActions,
   StyledTrackHeader,
   StyledUpNext,
@@ -198,13 +196,14 @@ export const CurrentAgenda = ({
                   <AgendaSession room={3} sessionId="1002367" />
                   <AgendaSession
                     room={4}
+                    isWorkshop
                     sessionId="1045279"
                     renderTitle={(title) => (
-                      <StyledAgendaTitle>{title}<br />(Part 1)</StyledAgendaTitle>
+                      <StyledAgendaTitle>{title}</StyledAgendaTitle>
                     )}
                   />
                   <AgendaTime time={set(date, { hours: 14, minutes: 15 })} />
-                  <AgendaSession fullWidth>
+                  <AgendaSession fullWidth excludeWorkshopTrack>
                     <StyledTrackHeader>Changeover</StyledTrackHeader>
                   </AgendaSession>
                   <AgendaTime time={set(date, { hours: 14, minutes: 30 })} duration={45} />
@@ -218,9 +217,11 @@ export const CurrentAgenda = ({
                   <AgendaSession room={3} sessionId="1029734" />
                   <AgendaSession
                     room={4}
+                    isWorkshop
+                    isWorkshopContinuation
                     sessionId="1045279"
                     renderTitle={(title) => (
-                      <StyledAgendaTitle>{title}<br />(Part 2)</StyledAgendaTitle>
+                      <StyledAgendaTitle>{title}<br />(continued)</StyledAgendaTitle>
                     )}
                   />
                   <AgendaTime time={set(date, { hours: 15, minutes: 15 })} />


### PR DESCRIPTION
This PR includes changes to the layout of the agenda to allow for workshops to be included that can go over multiple tracks and break periods.

The layout of the agenda table has been changed to accommodate this, by making the full "table" use a CSS grid, rather than having a grid per row.

## Up next / Next session
There is an "up next / next session" feature that DDD Melbourne do not currently use, which I have also updated the layout of to match.

## Mobile display of workshops
A second ("Continued") session is included for each workshop, which is only shown on mobile display.  This is achieved using the "isWorkshopContinuation" property that has been added to the `AgendaSession` component.

## Screenshot of final implementation
Here is a screenshot from my dev environment of how it looks:

<img width="2292" height="3600" alt="image" src="https://github.com/user-attachments/assets/97199291-4634-4828-b74c-5ab62a4fc1cc" />
